### PR TITLE
Dot trendline for unfinished day

### DIFF
--- a/components/index/Chart.vue
+++ b/components/index/Chart.vue
@@ -33,8 +33,9 @@
       let finishedDaysLength = days
       if (!lastDayFinished && days > 0) {
         const unfinishedDayFraction = (latest - new Date(latest).setHours(0, 0, 0, 0)) / (24 * 60 * 60 * 1000)
+        const lastFinishedDayData = data[data.length - 2]
         const unfinishedDayData = data.pop()
-        const extrapolated = unfinishedDayData / unfinishedDayFraction
+        const extrapolated = unfinishedDayData + lastFinishedDayData * (1 - unfinishedDayFraction)
         finishedDaysLength = days - 1
         data.push({
           y: extrapolated,

--- a/components/index/Chart.vue
+++ b/components/index/Chart.vue
@@ -29,7 +29,18 @@
       daysArray.reverse()
 
       const lastDayFinished = new Date(latest).setHours(23, 59, 59, 999) < Date.now()
-      const finishedDaysLength = lastDayFinished ? days : days - 1
+      let data = this.txHistory.map(h => h.value)
+      let finishedDaysLength = days
+      if (!lastDayFinished && days > 0) {
+        const unfinishedDayFraction = (latest - new Date(latest).setHours(0, 0, 0, 0)) / (24 * 60 * 60 * 1000)
+        const unfinishedDayData = data.pop()
+        const extrapolated = unfinishedDayData / unfinishedDayFraction
+        finishedDaysLength = days - 1
+        data.push({
+          y: extrapolated,
+          tooltip: `Extrapolated to ${extrapolated.toFixed(0)} from ${unfinishedDayData}`
+        })
+      }
 
       // console.log('daysArray', daysArray)
       return {
@@ -63,7 +74,7 @@
             shared: false,
             valueSuffix: '',
             formatter: function () {
-              return this.y
+              return this.point.tooltip || this.y
             }
           },
           credits: {
@@ -80,7 +91,7 @@
           },
           series: [ {
             name: '',
-            data: this.txHistory.map(h => h.value),
+            data: data,
             zoneAxis: 'x',
             zones: [{ value: finishedDaysLength - 1 }, { dashStyle: 'shortdot', fillColor: 'transparent' }]
           }]

--- a/components/index/Chart.vue
+++ b/components/index/Chart.vue
@@ -36,10 +36,18 @@
         const lastFinishedDayData = data[data.length - 2]
         const unfinishedDayData = data.pop()
         const extrapolated = unfinishedDayData + lastFinishedDayData * (1 - unfinishedDayFraction)
+
         finishedDaysLength = days - 1
         data.push({
+          x: finishedDaysLength,
           y: extrapolated,
-          tooltip: `Extrapolated to ${extrapolated.toFixed(0)} from ${unfinishedDayData}`
+          tooltip: `Extrapolated to ~${extrapolated.toFixed(0)} from ${unfinishedDayData}`
+        })
+        data.push(null) // Break line and draw unextrapolated marker too
+        data.push({
+          x: finishedDaysLength,
+          y: unfinishedDayData,
+          marker: { enabled: true }
         })
       }
 

--- a/components/index/Chart.vue
+++ b/components/index/Chart.vue
@@ -27,6 +27,10 @@
         daysArray.push(thatDay.getDate() + '<br/>' + getMonth(thatDay.getMonth()))
       }
       daysArray.reverse()
+
+      const lastDayFinished = new Date(latest).setHours(23, 59, 59, 999) < Date.now()
+      const finishedDaysLength = lastDayFinished ? days : days - 1
+
       // console.log('daysArray', daysArray)
       return {
         chartOptions: {
@@ -76,7 +80,9 @@
           },
           series: [ {
             name: '',
-            data: this.txHistory.map(h => h.value)
+            data: this.txHistory.map(h => h.value),
+            zoneAxis: 'x',
+            zones: [{ value: finishedDaysLength - 1 }, { dashStyle: 'shortdot', fillColor: 'transparent' }]
           }]
         }
       }


### PR DESCRIPTION
When looking at transaction history in mornings, it looks like a crash. This mitigates it by dotting the line of last day.

| Before | After | After2 |
| --- | --- | --- |
| ![tbefore](https://user-images.githubusercontent.com/3758846/121745748-173bc480-cb05-11eb-820e-3d430e613c9a.png) | ![0 0 0 0_8081_](https://user-images.githubusercontent.com/3758846/121756691-4a894e00-cb1b-11eb-8925-b195cb124be5.png) | ![0 0 0 0_8081_](https://user-images.githubusercontent.com/3758846/121967007-e14e4880-cd6f-11eb-960e-65917a21c71e.png) |

