### PR TITLE
_blockNumber: fix absolute time

### DIFF
--- a/pages/blocks/_blockNumber.vue
+++ b/pages/blocks/_blockNumber.vue
@@ -10,7 +10,7 @@
           </div>
         </template>
         <template #timestamp>
-          <span>{{ data.timestamp.value | timeFormat }} ({{ data.value | timeFormat2 }})</span>
+          <span>{{ data.timestamp.value | timeFormat }} ({{ data.timestamp.value | timeFormat2 }})</span>
         </template>
       </Description>
     </Panel>


### PR DESCRIPTION
viewing a block shows the relative time, but the absolute time instead shows the current time.

example: https://www.oasisscan.com/blocks/12345678

> Time / a year ago (2024-02-08 17:00:23)